### PR TITLE
numbfs: implement superblock and inode handling with writeback support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@
 #
 obj-m += numbfs.o
 
-numbfs-objs := super.o inode.o
+numbfs-objs := super.o inode.o utils.o

--- a/inode.c
+++ b/inode.c
@@ -9,23 +9,69 @@
 
 static int numbfs_fill_inode(struct inode *inode)
 {
-        //TODO: XXX
-        inode->i_mode = (inode->i_mode & ~S_IFMT) | S_IFDIR;
-        return 0;
+        struct super_block *sb = inode->i_sb;
+        struct numbfs_inode_info *ni = NUMBFS_I(inode);
+        struct numbfs_buf buf;
+        struct numbfs_inode *di;
+        int err, i;
+
+        /* on-disk inode information */
+        di = numbfs_idisk(&buf, sb, inode->i_ino);
+        if (IS_ERR(di)) {
+                numbfs_put_buf(&buf);
+                return PTR_ERR(di);
+        }
+
+        inode->i_mode = le32_to_cpu(di->i_mode);
+        i_uid_write(inode, le16_to_cpu(di->i_uid));
+        i_gid_write(inode, le16_to_cpu(di->i_gid));
+        set_nlink(inode, le16_to_cpu(di->i_nlink));
+        inode->i_size = le32_to_cpu(di->i_size);
+        inode->i_blocks = round_up(inode->i_size, sb->s_blocksize) >> 9;
+
+        ni->sbi = NUMBFS_SB(sb);
+        ni->nid = inode->i_ino;
+        for (i = 0; i < NUMBFS_NUM_DATA_ENTRY; i++)
+                ni->data[i] = le32_to_cpu(di->i_data[i]);
+
+        numbfs_put_buf(&buf);
+
+        err = 0;
+        switch(inode->i_mode & S_IFMT) {
+        case S_IFREG:
+                err = -EOPNOTSUPP;
+                break;
+        case S_IFLNK:
+                err = -EOPNOTSUPP;
+                break;
+        case S_IFDIR:
+                // TODO: XXX
+                err = 0;
+                break;
+        default:
+                err = -EOPNOTSUPP;
+                goto out;
+        }
+out:
+        return err;
 }
 
 static int numbfs_iget5_eq(struct inode *inode, void *nid)
 {
-        // TODO: XXX
-        return 0;
+        struct numbfs_inode_info *ni = NUMBFS_I(inode);
+
+        return ni->nid == *(int*)nid;
 }
 
 static int numbfs_iget5_set(struct inode *inode, void *data)
 {
-        // TODO: XXX
+        struct numbfs_inode_info *ni = NUMBFS_I(inode);
+        int nid = *(int*)data;
+
+        inode->i_ino = nid;
+        ni->nid = nid;
         return 0;
 }
-
 
 struct inode *numbfs_iget(struct super_block *sb, int nid)
 {

--- a/utils.c
+++ b/utils.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2025, Hongzhen Luo
+ */
+
+#include "internal.h"
+#include <linux/mm.h>
+#include <linux/pagemap.h>
+#include <linux/writeback.h>
+#include <linux/buffer_head.h>
+
+void numbfs_init_buf(struct numbfs_buf *buf, struct inode *inode,
+                         int blk)
+{
+        buf->inode = inode;
+        buf->blkaddr = blk;
+        buf->folio = NULL;
+        buf->base = NULL;
+}
+
+int numbfs_read_buf(struct numbfs_buf *buf)
+{
+        struct inode *inode = buf->inode;
+        pgoff_t index = (buf->blkaddr << NUMBFS_BLOCK_BITS) >> PAGE_SHIFT;
+        struct folio *folio;
+
+        folio = read_cache_folio(inode->i_mapping, index, NULL, NULL);
+        if (IS_ERR(folio)) {
+                pr_info("numbfs: folio is error in numbfs_read_buf\n");
+                return PTR_ERR(folio);
+        }
+
+        buf->base = kmap_local_folio(folio, 0);
+        buf->folio = folio;
+        return 0;
+}
+
+int numbfs_commit_buf(struct numbfs_buf *buf)
+{
+        struct inode *inode = buf->inode;
+        struct folio *folio = buf->folio;
+
+        folio_mark_dirty(folio);
+        block_write_end(NULL, inode->i_mapping, folio_pos(folio),
+                folio_size(folio), folio_size(folio), &folio->page, NULL);
+        return 0;
+}
+
+void numbfs_put_buf(struct numbfs_buf *buf)
+{
+        if (!buf->folio)
+                return;
+
+        kunmap_local(buf->base);
+        buf->base = NULL;
+        folio_put(buf->folio);
+        buf->folio = NULL;
+}


### PR DESCRIPTION
This PR implements core superblock and inode handling functionality for numbfs, including read support, caching mechanisms, and proper writeback on unmount.